### PR TITLE
Move readonly role to the /nubis/ path, to avoid calshes with usernames

### DIFF
--- a/modules/global/admins/main.tf
+++ b/modules/global/admins/main.tf
@@ -61,7 +61,7 @@ EOF
 
 resource "aws_iam_role" "readonly" {
     count = 1
-    path  = "/nubis/admin/"
+    path  = "/nubis/"
     name = "readonly"
     assume_role_policy = <<EOF
 {


### PR DESCRIPTION
Fixes #46