### PR TITLE
Just remove documentation references to aws_profile.

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,9 +88,6 @@ $> cp variables.tf-dist variables.tf
 # Name of the account (used for display and resources)
 account_name = "some-account-name"
 
-# The name of the profile in your ~/.aws/credentials file
-aws_profile  = "project-foo"
-
 # The version of the platform you want
 nubis_version = "v1.1.0"
 

--- a/terraform.tfvars-dist
+++ b/terraform.tfvars-dist
@@ -1,9 +1,6 @@
 # Name of the account (used for display and resources)
 account_name = "some-account-name"
 
-# The name of the profile in your ~/.aws/credentials file
-aws_profile  = "some-account-name-profile"
-
 # The version of the platform you want
 nubis_version = "v1.1.0"
 


### PR DESCRIPTION
With aws-vault, it's not needed, but in general, it could remain useful,
so lets leave it in, just not talk about it specifically

Fixes #49