### PR TITLE
Require MFA device to deregister a MFA device

### DIFF
--- a/modules/global/admins/mfa-policy.json.tmpl
+++ b/modules/global/admins/mfa-policy.json.tmpl
@@ -51,6 +51,19 @@
       ]
     },
     {
+      "Sid": "DeactivatingMFANeedsMFA",
+      "Effect": "Deny",
+      "Action": [
+        "iam:DeactivateMFADevice"
+      ],
+      "Resource": "*",
+      "Condition": {
+        "Bool": {
+          "aws:MultiFactorAuthPresent": "false"
+        }
+      }
+    },
+    {
       "Sid": "DoNotAllowAnythingOtherThanAboveUnlessMFAd",
       "Effect": "Deny",
       "NotAction": "iam:*",


### PR DESCRIPTION
Done by adding one explicit deny for removal of an MFA device *without*
using a MFA device, whichever one.

Fixes #108
Helps nubisproject/nubis-meta#22