### PR TITLE
make sure the CI instances get only placed into the admin credstash policy

### DIFF
--- a/modules/vpc/main.tf
+++ b/modules/vpc/main.tf
@@ -900,7 +900,7 @@ resource "aws_iam_policy_attachment" "credstash" {
 
   #XXX: concat and compact should work here, but element() isn't a list, so BUG
   roles = [
-    "${split(",",replace(replace(concat(element(split(",",module.jumphost.iam_roles), count.index), ",", element(split(",",module.consul.iam_roles), count.index), ",", element(split(",",module.fluent-collector.iam_roles), count.index), ",", element(aws_iam_role.nat.*.id, count.index), ",", element(aws_iam_role.user_management.*.id, count.index), ",", module.ci.iam_role ), "/(,+)/",","),"/(^,+|,+$)/", ""))}",
+    "${split(",",replace(replace(concat(element(split(",",module.jumphost.iam_roles), count.index), ",", element(split(",",module.consul.iam_roles), count.index), ",", element(split(",",module.fluent-collector.iam_roles), count.index), ",", element(aws_iam_role.nat.*.id, count.index), ",", element(aws_iam_role.user_management.*.id, count.index), ",", element(split(",",replace(module.ci.iam_role, "/$/",replace(var.environments, "/[^,]+/","") )), count.index) ), "/(,+)/",","),"/(^,+|,+$)/", ""))}",
   ]
 
   #XXX: Bug, puts the CI system in all environment roles


### PR DESCRIPTION
The TF juggling required here is nasty.

 var.environment =~ s/[^,]//
    admin,stage,prod => ,,

Then we concatenate with a regular expression again, the single IAM role
returned by CI:

  var.ci_role =~ s/$/,,/

So finally, we have a string that looks like:
  ci-role-arn,,

Then, we can index in there with element(var.ci_role, count.index)

And we'll get the correct ARN in the first VPC, then an empty value
in the other ones.

It's fugly, I know, and TF 0.7 will make all that juggling unnecessary