### PR TITLE
[review] Bubble up userdata for nubis user groups

### DIFF
--- a/input.tf
+++ b/input.tf
@@ -146,6 +146,13 @@ variable user_management {
   }
 }
 
+variable jumphost {
+  default = {
+    sudo_groups = "nubis_global_admins"
+    user_groups = ""
+  }
+}
+
 variable fluentd {
   default = {
     sqs_queues      = ""

--- a/main.tf
+++ b/main.tf
@@ -107,6 +107,10 @@ module "vpcs" {
   fluentd_sqs_secret_keys = "${lookup(var.fluentd, "sqs_secret_keys")}"
   fluentd_sqs_regions     = "${lookup(var.fluentd, "sqs_regions")}"
 
+  # jumphost groups
+  jumphost_sudo_groups    = "${lookup(var.jumphost, "sudo_groups")}"
+  jumphost_user_groups    = "${lookup(var.jumphost, "user_groups")}"
+
   # user management
   user_management_smtp_from_address  = "${lookup(var.user_management, "smtp_from_address")}"
   user_management_smtp_username      = "${lookup(var.user_management, "smtp_username")}"

--- a/modules/global/vpcs/inputs.tf
+++ b/modules/global/vpcs/inputs.tf
@@ -115,3 +115,6 @@ variable fluentd_sqs_access_keys {}
 variable fluentd_sqs_secret_keys {}
 
 variable fluentd_sqs_regions {}
+
+variable jumphost_sudo_groups {}
+variable jumphost_user_groups {}

--- a/modules/global/vpcs/main.tf
+++ b/modules/global/vpcs/main.tf
@@ -74,6 +74,10 @@ module "us-east-1" {
   fluentd_sqs_secret_keys = "${var.fluentd_sqs_secret_keys}"
   fluentd_sqs_regions     = "${var.fluentd_sqs_regions}"
 
+  # jumphost user groups
+  jumphost_sudo_groups    = "${var.jumphost_sudo_groups}"
+  jumphost_user_groups    = "${var.jumphost_user_groups}"
+
   # user management
   user_management_smtp_from_address  = "${var.user_management_smtp_from_address}"
   user_management_smtp_username      = "${var.user_management_smtp_username}"
@@ -168,6 +172,10 @@ module "us-west-2" {
   fluentd_sqs_access_keys = "${var.fluentd_sqs_access_keys}"
   fluentd_sqs_secret_keys = "${var.fluentd_sqs_secret_keys}"
   fluentd_sqs_regions     = "${var.fluentd_sqs_regions}"
+
+  # Jumphost user groups
+  jumphost_sudo_groups    = "${var.jumphost_sudo_groups}"
+  jumphost_user_groups    = "${var.jumphost_user_groups}"
 
   # user management
   user_management_smtp_from_address  = "${var.user_management_smtp_from_address}"

--- a/modules/vpc/inputs.tf
+++ b/modules/vpc/inputs.tf
@@ -137,3 +137,6 @@ variable fluentd_sqs_access_keys {}
 variable fluentd_sqs_secret_keys {}
 
 variable fluentd_sqs_regions {}
+
+variable jumphost_sudo_groups {}
+variable jumphost_user_groups {}

--- a/modules/vpc/main.tf
+++ b/modules/vpc/main.tf
@@ -932,6 +932,9 @@ module "jumphost" {
   nubis_domain = "${var.nubis_domain}"
 
   service_name = "${var.account_name}"
+
+  nubis_sudo_groups = "${var.jumphost_sudo_groups}"
+  nubis_user_groups = "${var.jumphost_user_groups}"
 }
 
 module "fluent-collector" {


### PR DESCRIPTION
We have added userdata to specify which ldap groups our puppet module
should look at when creating our users. This userdata has been added in
the jumphost module so I'm bubbling up the inputs in the nubis-deploy
repo

Fixes issue #164 