### PR TITLE
Ability to accept multiple groups for user_management

### DIFF
--- a/input.tf
+++ b/input.tf
@@ -143,8 +143,7 @@ variable user_management {
     ldap_bind_password = "xxxxx"
     tls_cert           = "user_management.crt"
     tls_key            = "user_management.key"
-    global_admins      = "nubis_global_admins"
-    sudo_users         = "nubis_sudo_users"
+    sudo_users         = "nubis_global_admins,nubis_sudo_users"
     users              = "nubis_users"
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -127,7 +127,6 @@ module "vpcs" {
   user_management_ldap_bind_password = "${lookup(var.user_management, "ldap_bind_password")}"
   user_management_tls_cert           = "${lookup(var.user_management, "tls_cert")}"
   user_management_tls_key            = "${lookup(var.user_management, "tls_key")}"
-  user_management_global_admins      = "${lookup(var.user_management, "global_admins")}"
   user_management_sudo_users         = "${lookup(var.user_management, "sudo_users")}"
   user_management_users              = "${lookup(var.user_management, "users")}"
 }

--- a/modules/global/vpcs/inputs.tf
+++ b/modules/global/vpcs/inputs.tf
@@ -108,8 +108,6 @@ variable user_management_tls_cert {}
 
 variable user_management_tls_key {}
 
-variable user_management_global_admins {}
-
 variable user_management_sudo_users {}
 
 variable user_management_users {}

--- a/modules/global/vpcs/main.tf
+++ b/modules/global/vpcs/main.tf
@@ -94,7 +94,6 @@ module "us-east-1" {
   user_management_ldap_bind_password = "${var.user_management_ldap_bind_password}"
   user_management_tls_cert           = "${var.user_management_tls_cert}"
   user_management_tls_key            = "${var.user_management_tls_key}"
-  user_management_global_admins      = "${var.user_management_global_admins}"
   user_management_sudo_users         = "${var.user_management_sudo_users}"
   user_management_users              = "${var.user_management_users}"
 }
@@ -196,7 +195,6 @@ module "us-west-2" {
   user_management_ldap_bind_password = "${var.user_management_ldap_bind_password}"
   user_management_tls_cert           = "${var.user_management_tls_cert}"
   user_management_tls_key            = "${var.user_management_tls_key}"
-  user_management_global_admins      = "${var.user_management_global_admins}"
   user_management_sudo_users         = "${var.user_management_sudo_users}"
   user_management_users              = "${var.user_management_users}"
 }

--- a/modules/vpc/inputs.tf
+++ b/modules/vpc/inputs.tf
@@ -130,8 +130,6 @@ variable user_management_tls_cert {}
 
 variable user_management_tls_key {}
 
-variable user_management_global_admins {}
-
 variable user_management_sudo_users {}
 
 variable user_management_users {}

--- a/modules/vpc/main.tf
+++ b/modules/vpc/main.tf
@@ -1131,7 +1131,6 @@ module "user_management" {
   user_management_ldap_bind_password = "${var.user_management_ldap_bind_password}"
   user_management_tls_cert           = "${var.user_management_tls_cert}"
   user_management_tls_key            = "${var.user_management_tls_key}"
-  user_management_global_admins      = "${var.user_management_global_admins}"
   user_management_sudo_users         = "${var.user_management_sudo_users}"
   user_management_users              = "${var.user_management_users}"
 }
@@ -1644,9 +1643,8 @@ resource template_file "user_management_config" {
     ldap_bind_password      = "${var.user_management_ldap_bind_password}"
     tls_cert                = "${replace(file("${path.cwd}/${var.user_management_tls_cert}"), "/(.*)\\n/", "    $1\n")}"
     tls_key                 = "${replace(file("${path.cwd}/${var.user_management_tls_key}"), "/(.*)\\n/", "    $1\n")}"
-    global_admin_ldap_group = "${var.user_management_global_admins}"
-    sudo_user_ldap_group    = "${var.user_management_sudo_users}"
-    users_ldap_group        = "${var.user_management_users}"
+    sudo_user_ldap_group    = "${replace(var.user_management_sudo_users, ",", "|")}"
+    users_ldap_group        = "${replace(var.user_management_users, ",", "|")}"
   }
 }
 
@@ -1666,6 +1664,6 @@ resource "null_resource" "user_management_unicreds" {
   }
 
   provisioner "local-exec" {
-    command = "echo \"${element(template_file.user_management_config.*.rendered, count.index)}\" | ${self.triggers.unicreds}/user-sync/config /dev/stdin ${self.triggers.context}"
+    command = "echo '${element(template_file.user_management_config.*.rendered, count.index)}' | ${self.triggers.unicreds}/user-sync/config /dev/stdin ${self.triggers.context}"
   }
 }

--- a/modules/vpc/user_management.yml.tmpl
+++ b/modules/vpc/user_management.yml.tmpl
@@ -27,18 +27,12 @@ LdapServer:
   LDAPBindPassword: "${ldap_bind_password}"
   LDAPInsecure: false
   IAMGroupMapping:
-    - GlobalAdmins:
-      LDAPGroup: ${global_admin_ldap_group}
-      IAMPath: /nubis/admin/
-      ConsulPath: global-admins
     - SudoUsers:
-      LDAPGroup: ${sudo_user_ldap_group}
-      IAMPath: /nubis/readonly/
-      ConsulPath: sudo-users
+      LDAPGroup: "${sudo_user_ldap_group}"
+      IAMPath: /nubis/admin/
     - Users:
-      LDAPGroup: ${users_ldap_group}
+      LDAPGroup: "${users_ldap_group}"
       IAMPath: /nubis/readonly/
-      ConsulPath: users
   StartTLS: true
   TLSCrt: |
 ${tls_cert}

--- a/modules/vpc/user_management/inputs.tf
+++ b/modules/vpc/user_management/inputs.tf
@@ -38,8 +38,6 @@ variable user_management_tls_cert {}
 
 variable user_management_tls_key {}
 
-variable user_management_global_admins {}
-
 variable user_management_sudo_users {}
 
 variable user_management_users {}

--- a/modules/vpc/user_management/main.tf
+++ b/modules/vpc/user_management/main.tf
@@ -209,9 +209,8 @@ resource template_file "user_management_config_iam" {
     ldap_bind_password      = "${var.user_management_ldap_bind_password}"
     tls_cert                = "${replace(file("${path.cwd}/${var.user_management_tls_cert}"), "/(.*)\\n/", "    $1\n")}"
     tls_key                 = "${replace(file("${path.cwd}/${var.user_management_tls_key}"), "/(.*)\\n/", "    $1\n")}"
-    global_admin_ldap_group = "${var.user_management_global_admins}"
-    sudo_user_ldap_group    = "${var.user_management_sudo_users}"
-    users_ldap_group        = "${var.user_management_users}"
+    sudo_user_ldap_group    = "${replace(var.user_management_sudo_users, ",", "|")}"
+    users_ldap_group        = "${replace(var.user_management_users, ",", "|")}"
   }
 }
 


### PR DESCRIPTION
User management should be able to dish out multiple groups, this patch
fixes that issue by fixing the configs to be able to take multiple
groups. We accept the list as a comma seperated list but when terraform
generates the template it translates "," to "|" so that it doesn't look
weird for end users.