### PR TITLE
Rename variables so that it doesn't sound confusing

### DIFF
--- a/input.tf
+++ b/input.tf
@@ -145,8 +145,8 @@ variable user_management {
     ldap_bind_password = "xxxxx"
     tls_cert           = "user_management.crt"
     tls_key            = "user_management.key"
-    sudo_users         = "nubis_global_admins,nubis_sudo_users"
-    users              = "nubis_users"
+    sudo_groups        = "nubis_global_admins,nubis_sudo_users"
+    user_groups        = "nubis_users"
   }
 }
 

--- a/main.tf
+++ b/main.tf
@@ -131,6 +131,6 @@ module "vpcs" {
   user_management_ldap_bind_password = "${lookup(var.user_management, "ldap_bind_password")}"
   user_management_tls_cert           = "${lookup(var.user_management, "tls_cert")}"
   user_management_tls_key            = "${lookup(var.user_management, "tls_key")}"
-  user_management_sudo_users         = "${lookup(var.user_management, "sudo_users")}"
-  user_management_users              = "${lookup(var.user_management, "users")}"
+  user_management_sudo_groups        = "${lookup(var.user_management, "sudo_groups")}"
+  user_management_user_groups        = "${lookup(var.user_management, "user_groups")}"
 }

--- a/modules/global/vpcs/inputs.tf
+++ b/modules/global/vpcs/inputs.tf
@@ -112,9 +112,9 @@ variable user_management_tls_cert {}
 
 variable user_management_tls_key {}
 
-variable user_management_sudo_users {}
+variable user_management_sudo_groups {}
 
-variable user_management_users {}
+variable user_management_user_groups {}
 
 variable fluentd_sqs_queues {}
 

--- a/modules/global/vpcs/main.tf
+++ b/modules/global/vpcs/main.tf
@@ -98,8 +98,8 @@ module "us-east-1" {
   user_management_ldap_bind_password = "${var.user_management_ldap_bind_password}"
   user_management_tls_cert           = "${var.user_management_tls_cert}"
   user_management_tls_key            = "${var.user_management_tls_key}"
-  user_management_sudo_users         = "${var.user_management_sudo_users}"
-  user_management_users              = "${var.user_management_users}"
+  user_management_sudo_groups        = "${var.user_management_sudo_groups}"
+  user_management_user_groups        = "${var.user_management_user_groups}"
 }
 
 # XXX: Yes, cut-n-paste, can't be helped at the moment
@@ -203,6 +203,6 @@ module "us-west-2" {
   user_management_ldap_bind_password = "${var.user_management_ldap_bind_password}"
   user_management_tls_cert           = "${var.user_management_tls_cert}"
   user_management_tls_key            = "${var.user_management_tls_key}"
-  user_management_sudo_users         = "${var.user_management_sudo_users}"
-  user_management_users              = "${var.user_management_users}"
+  user_management_sudo_groups        = "${var.user_management_sudo_groups}"
+  user_management_user_groups        = "${var.user_management_user_groups}"
 }

--- a/modules/vpc/inputs.tf
+++ b/modules/vpc/inputs.tf
@@ -134,9 +134,9 @@ variable user_management_tls_cert {}
 
 variable user_management_tls_key {}
 
-variable user_management_sudo_users {}
+variable user_management_sudo_groups {}
 
-variable user_management_users {}
+variable user_management_user_groups {}
 
 variable fluentd_sqs_queues {}
 

--- a/modules/vpc/main.tf
+++ b/modules/vpc/main.tf
@@ -1137,8 +1137,8 @@ module "user_management" {
   user_management_ldap_bind_password = "${var.user_management_ldap_bind_password}"
   user_management_tls_cert           = "${var.user_management_tls_cert}"
   user_management_tls_key            = "${var.user_management_tls_key}"
-  user_management_sudo_users         = "${var.user_management_sudo_users}"
-  user_management_users              = "${var.user_management_users}"
+  user_management_sudo_groups        = "${var.user_management_sudo_groups}"
+  user_management_user_groups        = "${var.user_management_user_groups}"
 }
 
 #XXX: Move to a module
@@ -1649,8 +1649,8 @@ resource template_file "user_management_config" {
     ldap_bind_password      = "${var.user_management_ldap_bind_password}"
     tls_cert                = "${replace(file("${path.cwd}/${var.user_management_tls_cert}"), "/(.*)\\n/", "    $1\n")}"
     tls_key                 = "${replace(file("${path.cwd}/${var.user_management_tls_key}"), "/(.*)\\n/", "    $1\n")}"
-    sudo_user_ldap_group    = "${replace(var.user_management_sudo_users, ",", "|")}"
-    users_ldap_group        = "${replace(var.user_management_users, ",", "|")}"
+    sudo_user_ldap_group    = "${replace(var.user_management_sudo_groups, ",", "|")}"
+    users_ldap_group        = "${replace(var.user_management_user_groups, ",", "|")}"
   }
 }
 

--- a/modules/vpc/user_management/inputs.tf
+++ b/modules/vpc/user_management/inputs.tf
@@ -38,6 +38,6 @@ variable user_management_tls_cert {}
 
 variable user_management_tls_key {}
 
-variable user_management_sudo_users {}
+variable user_management_sudo_groups {}
 
-variable user_management_users {}
+variable user_management_user_groups {}

--- a/modules/vpc/user_management/main.tf
+++ b/modules/vpc/user_management/main.tf
@@ -209,8 +209,8 @@ resource template_file "user_management_config_iam" {
     ldap_bind_password      = "${var.user_management_ldap_bind_password}"
     tls_cert                = "${replace(file("${path.cwd}/${var.user_management_tls_cert}"), "/(.*)\\n/", "    $1\n")}"
     tls_key                 = "${replace(file("${path.cwd}/${var.user_management_tls_key}"), "/(.*)\\n/", "    $1\n")}"
-    sudo_user_ldap_group    = "${replace(var.user_management_sudo_users, ",", "|")}"
-    users_ldap_group        = "${replace(var.user_management_users, ",", "|")}"
+    sudo_user_ldap_group    = "${replace(var.user_management_sudo_groups, ",", "|")}"
+    users_ldap_group        = "${replace(var.user_management_user_groups, ",", "|")}"
   }
 }
 


### PR DESCRIPTION
Rename `sudo_users` -> `sudo_groups` and `users` -> `user_groups`