### PR TITLE
Create an images/ TF module to search for Nubis AMIs

### DIFF
--- a/modules/images/input.tf
+++ b/modules/images/input.tf
@@ -1,0 +1,17 @@
+variable "region" {}
+
+variable "project" {}
+
+variable "version" {}
+
+variable "os" {
+  default = "*"
+}
+
+variable "storage" {
+  default = "ebs"
+}
+
+variable "owner" {
+  default = "589768463761"
+}

--- a/modules/images/main.tf
+++ b/modules/images/main.tf
@@ -1,0 +1,22 @@
+provider "aws" {
+  region = "${var.region}"
+}
+
+data "aws_ami" "image" {
+  most_recent = true
+
+  filter {
+    name   = "state"
+    values = ["available"]
+  }
+
+  filter {
+    name = "name"
+
+    values = [
+      "${var.project} ${var.version} ${var.storage} ${var.os}",
+    ]
+  }
+
+  owners = ["${var.owner}"]
+}

--- a/modules/images/output.tf
+++ b/modules/images/output.tf
@@ -1,0 +1,7 @@
+output "image_id" {
+  value = "${data.aws_ami.image.image_id}"
+}
+
+output "name" {
+  value = "${data.aws_ami.image.name}"
+}

--- a/modules/vpc/main.tf
+++ b/modules/vpc/main.tf
@@ -718,15 +718,12 @@ resource "aws_network_interface" "private-nat" {
   ]
 }
 
-data "atlas_artifact" "nubis-nat" {
-  count = "${var.enabled * var.enable_nat}"
+module "nat-image" {
+  source = "../images"
 
-  name = "nubisproject/nubis-nat"
-  type = "amazon.image"
-
-  metadata {
-    project_version = "${var.nubis_version}"
-  }
+  region = "${var.aws_region}"
+  version = "${var.nubis_version}"
+  project = "nubis-nat"
 }
 
 variable nat_side {
@@ -798,7 +795,7 @@ resource "aws_launch_configuration" "nat" {
 
   name_prefix = "nubis-nat-${element(split(",",var.environments), count.index/2 )}-${lookup(var.nat_side, count.index % 2)}-"
 
-  image_id = "${data.atlas_artifact.nubis-nat.metadata_full["region-${var.aws_region}"]}"
+  image_id = "${module.nat-image.image_id}"
 
   instance_type               = "t2.small"
   associate_public_ip_address = true


### PR DESCRIPTION
And this way, we don't need Atlas to mediate our AMI searching anymore

Fixes #195