### PR TITLE
Simplify our IAM policy for Admins and MFA access

### DIFF
--- a/modules/global/admins/mfa-policy.json.tmpl
+++ b/modules/global/admins/mfa-policy.json.tmpl
@@ -2,75 +2,47 @@
   "Version": "2012-10-17",
   "Statement": [
     {
-      "Sid": "AllowAllUsersToListAccounts",
+      "Sid": "AllowIndividualUserToListVirtualMFADevices",
       "Effect": "Allow",
       "Action": [
-        "iam:ListUsers",
-        "iam:ListAccountAliases"
-      ],
-      "Resource": [
-        "arn:aws:iam::${account_id}:user/*"
-      ]
-    },
-    {
-      "Sid": "AllowIndividualUserToSeeTheirAccountInformation",
-      "Effect": "Allow",
-      "Action": [
-        "iam:ChangePassword",
-        "iam:CreateLoginProfile",
-        "iam:DeleteLoginProfile",
-        "iam:GetAccountPasswordPolicy",
-        "iam:GetAccountSummary",
-        "iam:GetLoginProfile",
-        "iam:UpdateLoginProfile"
-      ],
-      "Resource": [
-        "arn:aws:iam::${account_id}:user/$${aws:username}"
-      ]
-    },
-    {
-      "Sid": "AllowIndividualUserToListTheirMFA",
-      "Effect": "Allow",
-      "Action": [
-        "iam:ListVirtualMFADevices",
-        "iam:ListMFADevices"
+        "iam:ListVirtualMFADevices"
       ],
       "Resource": "*"
+    },
+    {
+      "Sid": "AllowIndividualUserToCreateThierMFA",
+      "Effect": "Allow",
+      "Action": [
+        "iam:CreateVirtualMFADevice"
+      ],
+      "Resource": [
+        "arn:aws:iam::${account_id}:mfa/$${aws:username}"
+      ]
     },
     {
       "Sid": "AllowIndividualUserToManageThierMFA",
       "Effect": "Allow",
       "Action": [
-        "iam:CreateVirtualMFADevice",
         "iam:EnableMFADevice",
         "iam:ResyncMFADevice"
       ],
       "Resource": [
-        "arn:aws:iam::${account_id}:mfa/$${aws:username}",
-        "arn:aws:iam::${account_id}:user/$${aws:username}"
+        "arn:aws:iam::${account_id}:user/nubis/admin/$${aws:username}"
       ]
     },
     {
-      "Sid": "DeactivatingMFANeedsMFA",
-      "Effect": "Deny",
+      "Sid": "AllowIndividualUserToAssumeRole",
+      "Effect": "Allow",
       "Action": [
-        "iam:DeactivateMFADevice"
+        "sts:AssumeRole"
       ],
-      "Resource": "*",
+      "Resource": [
+        "arn:aws:iam::${account_id}:role/nubis/admin/$${aws:username}",
+	"arn:aws:iam::${account_id}:role/nubis/readonly"
+      ],
       "Condition": {
         "Bool": {
-          "aws:MultiFactorAuthPresent": "false"
-        }
-      }
-    },
-    {
-      "Sid": "DoNotAllowAnythingOtherThanAboveUnlessMFAd",
-      "Effect": "Deny",
-      "NotAction": "iam:*",
-      "Resource": "*",
-      "Condition": {
-        "Null": {
-          "aws:MultiFactorAuthAge": "true"
+          "aws:MultiFactorAuthPresent": "true"
         }
       }
     }


### PR DESCRIPTION
See individual commits for more details. Important note is that the end-result is simpler
and behaves as initially intended.

Without MFA, you can basically only setup your MFA device, and only your own.
With MFA, you can be an admin and do whatever you wish

Fixes #201