### PR TITLE
SSO options

### DIFF
--- a/input.tf
+++ b/input.tf
@@ -167,6 +167,8 @@ variable jumphost {
 
 variable sso {
   default = {
+    openid_client_id     = ""
+    openid_client_secret = ""
     sudo_groups = "nubis_global_admins"
     user_groups = ""
   }


### PR DESCRIPTION
If we default this to empty terraform will not ask to input these options even when we don't have a setting. I'm not sure what happens to SSO if we don't provide it with any information, but this should fix #248 