### PR TITLE
Enable sso module versioning

### DIFF
--- a/input.tf
+++ b/input.tf
@@ -171,6 +171,7 @@ variable sso {
     openid_client_secret = ""
     sudo_groups = "nubis_global_admins"
     user_groups = ""
+    version     = ""
   }
 }
 

--- a/main.tf
+++ b/main.tf
@@ -125,6 +125,7 @@ module "vpcs" {
   sso_openid_client_secret = "${lookup(var.sso, "openid_client_secret")}"
   sso_sudo_groups    = "${lookup(var.sso, "sudo_groups")}"
   sso_user_groups    = "${lookup(var.sso, "user_groups")}"
+  sso_version        = "${lookup(var.sso, "version")}"
 
   # user management
   user_management_smtp_from_address  = "${lookup(var.user_management, "smtp_from_address")}"

--- a/modules/global/vpcs/inputs.tf
+++ b/modules/global/vpcs/inputs.tf
@@ -136,6 +136,7 @@ variable sso_sudo_groups {}
 variable sso_user_groups {}
 variable sso_openid_client_id {}
 variable sso_openid_client_secret {}
+variable sso_version {}
 
 variable nat_sudo_groups {}
 variable nat_user_groups {}

--- a/modules/global/vpcs/main.tf
+++ b/modules/global/vpcs/main.tf
@@ -94,6 +94,7 @@ module "us-east-1" {
   sso_user_groups          = "${var.sso_user_groups}"
   sso_openid_client_id     = "${var.sso_openid_client_id}"
   sso_openid_client_secret = "${var.sso_openid_client_secret}"
+  sso_version              = "${var.sso_version}"
 
   # user management
   user_management_smtp_from_address  = "${var.user_management_smtp_from_address}"
@@ -227,6 +228,7 @@ module "us-west-2" {
   sso_user_groups    = "${var.sso_user_groups}"
   sso_openid_client_id     = "${var.sso_openid_client_id}"
   sso_openid_client_secret = "${var.sso_openid_client_secret}"
+  sso_version              = "${var.sso_version}"
 
   # user management
   user_management_smtp_from_address  = "${var.user_management_smtp_from_address}"

--- a/modules/vpc/inputs.tf
+++ b/modules/vpc/inputs.tf
@@ -159,6 +159,7 @@ variable sso_sudo_groups {}
 variable sso_user_groups {}
 variable sso_openid_client_id {}
 variable sso_openid_client_secret {}
+variable sso_version {}
 
 variable nat_sudo_groups {}
 variable nat_user_groups {}

--- a/modules/vpc/main.tf
+++ b/modules/vpc/main.tf
@@ -1051,7 +1051,7 @@ module "sso" {
   aws_region   = "${var.aws_region}"
 
   key_name          = "${var.ssh_key_name}"
-  nubis_version     = "${var.nubis_version}"
+  nubis_version     = "${coalesce(var.sso_version, var.nubis_version)}"
   technical_contact = "${var.technical_contact}"
 
   vpc_ids    = "${join(",", aws_vpc.nubis.*.id)}"


### PR DESCRIPTION
Fixes issue #261 PR allows you to specify a specific version of an sso AMI