### PR TITLE
Allow versioning of monitoring module

### DIFF
--- a/input.tf
+++ b/input.tf
@@ -128,6 +128,7 @@ variable monitoring {
     sudo_groups           = "nubis_global_admins"
     user_groups           = ""
     password              = ""
+    version               = ""
   }
 }
 

--- a/main.tf
+++ b/main.tf
@@ -119,6 +119,7 @@ module "vpcs" {
   monitoring_sudo_groups           = "${lookup(var.monitoring, "sudo_groups")}"
   monitoring_user_groups           = "${lookup(var.monitoring, "user_groups")}"
   monitoring_password              = "${lookup(var.monitoring, "password")}"
+  monitoring_version               = "${lookup(var.monitoring, "version")}"
 
   # fluentd
   fluentd                 = "${var.fluentd}"

--- a/modules/global/vpcs/inputs.tf
+++ b/modules/global/vpcs/inputs.tf
@@ -71,6 +71,8 @@ variable monitoring_sudo_groups {}
 variable monitoring_user_groups {}
 variable monitoring_password {}
 
+variable monitoring_version {}
+
 variable ci_project {}
 
 variable ci_git_repo {}

--- a/modules/global/vpcs/main.tf
+++ b/modules/global/vpcs/main.tf
@@ -82,6 +82,7 @@ module "us-east-1" {
   monitoring_sudo_groups           = "${var.monitoring_sudo_groups}"
   monitoring_user_groups           = "${var.monitoring_user_groups}"
   monitoring_password              = "${var.monitoring_password}"
+  monitoring_version               = "${var.monitoring_version}"
 
   # fluentd
   fluentd                 = "${var.fluentd}"
@@ -217,6 +218,7 @@ module "us-west-2" {
   monitoring_sudo_groups           = "${var.monitoring_sudo_groups}"
   monitoring_user_groups           = "${var.monitoring_user_groups}"
   monitoring_password              = "${var.monitoring_password}"
+  monitoring_version               = "${var.monitoring_version}"
 
   # fluentd
   fluentd                 = "${var.fluentd}"

--- a/modules/vpc/inputs.tf
+++ b/modules/vpc/inputs.tf
@@ -92,6 +92,8 @@ variable monitoring_user_groups {}
 
 variable monitoring_password {}
 
+variable monitoring_version {}
+
 variable ci_project {}
 
 variable ci_git_repo {}

--- a/modules/vpc/main.tf
+++ b/modules/vpc/main.tf
@@ -1034,7 +1034,7 @@ module "monitoring" {
   lambda_uuid_arn = "${aws_lambda_function.UUID.arn}"
 
   key_name          = "${var.ssh_key_name}"
-  nubis_version     = "${var.nubis_version}"
+  nubis_version     = "${coalesce(var.monitoring_version, var.nubis_version)}"
   technical_contact = "${var.technical_contact}"
 
   vpc_ids    = "${join(",", aws_vpc.nubis.*.id)}"


### PR DESCRIPTION
Allows us to specify a specific version of monitoring module. This allows us to build our own ami images to test