### PR TITLE
Revert "Small optimization, make our top-level zone use the same DNS delegation set (#399)"

### DIFF
--- a/modules/global/meta/main.tf
+++ b/modules/global/meta/main.tf
@@ -13,8 +13,6 @@ module "cloudhealth" {
 resource "aws_route53_zone" "master_zone" {
   name = "${var.account_name}.${var.nubis_domain}"
 
-  delegation_set_id = "${aws_route53_delegation_set.meta.id}"
-
   tags {
     ServiceName      = "${var.account_name}"
     TechnicalContact = "${var.technical_contact}"


### PR DESCRIPTION
This reverts commit 0789617e11aa9c8dcce37b2ba81077b814394567.