### PR TITLE
Restore images module

### DIFF
--- a/modules/images/input.tf
+++ b/modules/images/input.tf
@@ -1,0 +1,17 @@
+variable "region" {}
+
+variable "project" {}
+
+variable "version" {}
+
+variable "os" {
+  default = "*"
+}
+
+variable "storage" {
+  default = "ebs"
+}
+
+variable "owner" {
+  default = "589768463761"
+}

--- a/modules/images/main.tf
+++ b/modules/images/main.tf
@@ -1,0 +1,23 @@
+provider "aws" {
+  version = "~> 0.1"
+  region  = "${var.region}"
+}
+
+data "aws_ami" "image" {
+  most_recent = true
+
+  filter {
+    name   = "state"
+    values = ["available"]
+  }
+
+  filter {
+    name = "name"
+
+    values = [
+      "${var.project} ${var.version} ${var.storage} ${var.os}",
+    ]
+  }
+
+  owners = ["${var.owner}"]
+}

--- a/modules/images/output.tf
+++ b/modules/images/output.tf
@@ -1,0 +1,7 @@
+output "image_id" {
+  value = "${data.aws_ami.image.image_id}"
+}
+
+output "name" {
+  value = "${data.aws_ami.image.name}"
+}


### PR DESCRIPTION
We pin image search to develop in older tags when you remove this module from the repository upgrading to specific version of the nubis platform will fail.

Restoring this to maintain backward compatability