### PR TITLE
Set count at VPC level, not in module

### DIFF
--- a/modules/vpc/main.tf
+++ b/modules/vpc/main.tf
@@ -1178,9 +1178,8 @@ module "kube-image" {
 
 # FIXME: will only work once vpc and public state is created
 module "kubnernetes" {
-  source = "github.com/nubisproject/nubis-kubernetes//nubis/terraform?ref=develop"
-
-  enabled      = "${var.enabled * var.enable_kubernetes}"
+  source       = "github.com/nubisproject/nubis-kubernetes//nubis/terraform?ref=develop"
+  count        = "${var.enabled * var.enable_kubernetes}"
   region       = "${var.aws_region}"
   arena        = "${var.arenas[0]}"
   environment  = "deploy"


### PR DESCRIPTION
Only some of the resources in the kubernetes module had a count set.
This change disables the entire module if it is not desired.